### PR TITLE
feat: generate artifact attestations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,14 +52,30 @@ jobs:
       - name: Archive Ruby installation
         id: archive_ruby
         run: ./scripts/archive-ruby.sh ${{ matrix.ruby_version }} ${{ matrix.distro }}
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+      - name: Upload Ruby tarball as artifact
+        uses: actions/upload-artifact@v4
         with:
-          subject-path: ${{ steps.archive_ruby.outputs.ruby_tarball }}
+          path: ${{ steps.archive_ruby.outputs.ruby_tarball }}
+          retention-days: 1
+  upload-tarballs:
+    needs: build-linux
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download Ruby tarballs from artifact repository
+        uses: actions/download-artifact@v4
+      - name: Generate checksums
+        run: |
+          shasum --algorithm 256 --binary ruby-*.tar.xz > checksums.txt
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2.2.0
+        with:
+          subject-checksums: checksums.txt
       - name: Upload to release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         with:
-          files: ruby-${{ matrix.ruby_version }}*.tar.xz
+          files: |
+            ruby-*.tar.xz
+            checksums.txt
           fail_on_unmatched_files: true
           tag_name: binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
     permissions:
       # Needed for release upload
       contents: write
+      # Needed for build provenance
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup container
@@ -47,7 +50,12 @@ jobs:
       - name: Ruby version
         run: ruby --version
       - name: Archive Ruby installation
+        id: archive_ruby
         run: ./scripts/archive-ruby.sh ${{ matrix.ruby_version }} ${{ matrix.distro }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.archive_ruby.outputs.ruby_tarball }}
       - name: Upload to release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: ${{ matrix.distro }}
-    permissions:
-      # Needed for release upload
-      contents: write
-      # Needed for build provenance
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup container
@@ -61,6 +55,12 @@ jobs:
   upload-tarballs:
     needs: build-linux
     runs-on: ubuntu-24.04
+    permissions:
+      # Needed for release upload
+      contents: write
+      # Needed for build provenance
+      id-token: write
+      attestations: write
     steps:
       - name: Download Ruby tarballs from artifact repository
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,8 @@ jobs:
       - name: Upload Ruby tarball as artifact
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ steps.archive_ruby.outputs.ruby_tarball }}
+          name: ${{ steps.archive_ruby.outputs.ruby_tarball_filename }}
+          path: ${{ steps.archive_ruby.outputs.ruby_tarball_path }}
           retention-days: 1
   upload-tarballs:
     needs: build-linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         with:
           files: |
-            ruby-*.tar.xz
             checksums.txt
+            ruby-*.tar.xz
           fail_on_unmatched_files: true
           tag_name: binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - name: Download Ruby tarballs from artifact repository
         uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
       - name: Generate checksums
         run: |
           shasum --algorithm 256 --binary ruby-*.tar.xz > checksums.txt

--- a/scripts/archive-ruby.sh
+++ b/scripts/archive-ruby.sh
@@ -3,7 +3,10 @@
 set -eo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-BUILDER_DIR="$DIR/.."
+BUILDER_DIR="$(
+  cd "$DIR"/..
+  pwd -P
+)"
 
 ruby_version="$1"
 distro="$("$DIR"/normalize_distro.sh "$2")"

--- a/scripts/archive-ruby.sh
+++ b/scripts/archive-ruby.sh
@@ -19,11 +19,13 @@ binary_tarball_filename() {
   echo "ruby-${ruby_version}_${kernel,,}-$(uname -m)_${distro}.tar.xz"
 }
 
-tar_filename="$BUILDER_DIR/$(binary_tarball_filename)"
+tarball_filename="$(binary_tarball_filename)"
+tarball_path="$BUILDER_DIR/$tarball_filename"
 
 tar --directory="$HOME/.asdf/installs/ruby/$ruby_version" --create \
-  --file "$tar_filename" .
+  --file "$tarball_path" .
 
-ls -l "$tar_filename"
+ls -l "$tarball_path"
 
-echo "ruby_tarball=$tar_filename" >>"$GITHUB_OUTPUT"
+echo "ruby_tarball_filename=$tarball_filename" >>"$GITHUB_OUTPUT"
+echo "ruby_tarball_path=$tarball_path" >>"$GITHUB_OUTPUT"

--- a/scripts/archive-ruby.sh
+++ b/scripts/archive-ruby.sh
@@ -22,3 +22,5 @@ tar --directory="$HOME/.asdf/installs/ruby/$ruby_version" --create \
   --file "$tar_filename" .
 
 ls -l "$tar_filename"
+
+echo "ruby_tarball=$tar_filename" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
See [GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#generating-artifact-attestations-for-your-builds).