### PR TITLE
fix: ensure that tarball is compressed with xz

### DIFF
--- a/scripts/archive-ruby.sh
+++ b/scripts/archive-ruby.sh
@@ -8,6 +8,9 @@ BUILDER_DIR="$(
   pwd -P
 )"
 
+# shellcheck source=scripts/include/common.sh
+source "$DIR/include/common.sh"
+
 distro_name="$1"
 distro_version="$2"
 ruby_version="$3"
@@ -23,10 +26,14 @@ binary_tarball_filename() {
 tarball_filename="$(binary_tarball_filename)"
 tarball_path="$BUILDER_DIR/$tarball_filename"
 
-tar --directory="$HOME/.asdf/installs/ruby/$ruby_version" --create \
+tar --xz --directory="$HOME/.asdf/installs/ruby/$ruby_version" --create \
   --file "$tarball_path" .
 
 ls -l "$tarball_path"
 
-echo "ruby_tarball_filename=$tarball_filename" >>"$GITHUB_OUTPUT"
-echo "ruby_tarball_path=$tarball_path" >>"$GITHUB_OUTPUT"
+if ! file "$tarball_path" | grep -q 'XZ compressed data'; then
+  fail "Tarball is not compressed with 'xz'"
+fi
+
+persist_value ruby_tarball_filename "$tarball_filename"
+persist_value ruby_tarball_path "$tarball_path"

--- a/scripts/setup-container.sh
+++ b/scripts/setup-container.sh
@@ -12,8 +12,8 @@ distro_name="$1"
 version="$2"
 
 # xz is used for creating the tarballs
-extra_alpine_pkgs="xz"
-extra_ubuntu_pkgs="xz-utils"
+extra_alpine_pkgs="xz file"
+extra_ubuntu_pkgs="xz-utils file"
 if test -n "$ACT"; then
   # When using act, needs nodejs. Not necessary in hosted GH actions runner.
   extra_alpine_pkgs="$extra_alpine_pkgs nodejs"


### PR DESCRIPTION
#7 wasn't enough, I guess.

This also adds a check to see if the generated tarball is XZ-compressed via `file`.