### PR TITLE
chore(renovate): explicitly specify rangeStrategy

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,5 +17,7 @@
       ],
       "versioningTemplate": "ruby"
     }
-  ]
+  ],
+  // Need to specify a non-null value for the custom manager
+  "rangeStrategy": "auto",
 }


### PR DESCRIPTION
In theory, should fix the following:
> These problems occurred while renovating this repository. [View logs](https://developer.mend.io//github/malept/ruby-builder).
>
> > WARN: Unsupported range strategy