### PR TITLE
chore(renovate): revert custom manager

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,20 +4,4 @@
     "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "datasourceTemplate": "ruby-version",
-      "depNameTemplate": "ruby",
-      "managerFilePatterns": [
-        ".github/workflows/build.yml"
-      ],
-      "matchStrings": [
-        "# renovate: (?<depName>ruby)[\\r\\n]+(?<indentation>\\s*)?(?<currentValue>~> \\S+)"
-      ],
-      "versioningTemplate": "ruby"
-    }
-  ],
-  // Need to specify a non-null value for the custom manager
-  "rangeStrategy": "auto",
 }


### PR DESCRIPTION
Using a custom manager for Ruby versions does not currently work, see:
* https://github.com/renovatebot/renovate/discussions/28090