### PR TITLE
ci: disable mise cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         run: ./scripts/setup-container.sh ${{ steps.variables.outputs.distro_name }} ${{ matrix.ruby_version }}
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
+          cache: false
           log_level: info
           mise_toml: |
             [settings.ruby]
@@ -92,6 +93,7 @@ jobs:
         run: ./scripts/setup-macos.sh ${{ matrix.ruby_version }}
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
+          cache: false
           log_level: info
           mise_toml: |
             [settings.ruby]


### PR DESCRIPTION
We're only installing Ruby, and we want to build it each time.